### PR TITLE
Translatable submit button

### DIFF
--- a/resources/lang/en/support-bubble.php
+++ b/resources/lang/en/support-bubble.php
@@ -9,4 +9,5 @@ return [
     'email_label' => 'E-mail',
     'subject_label' => 'Subject',
     'message_label' => 'How can we help?',
+    'submit_label' => 'Submit',
 ];

--- a/resources/views/includes/form.blade.php
+++ b/resources/views/includes/form.blade.php
@@ -45,5 +45,5 @@
         />
     @endif
 
-    <button type="submit" class="{{ config('support-bubble.classes.button') }}">Submit</button>
+    <button type="submit" class="{{ config('support-bubble.classes.button') }}">{{ __('support-bubble::support-bubble.submit_label') }}</button>
 </form>

--- a/tests/Components/SupportBubbleComponentTest.php
+++ b/tests/Components/SupportBubbleComponentTest.php
@@ -23,7 +23,6 @@ it('can be configured not to use the logged in user', function () {
         ->assertDontSee('John Doe');
 });
 
-it('can render the submit button using the defult translation string', function () {
-    test()->blade('<x-support-bubble />')
-        ->assertSee('Submit');
-});
+it('can render the submit button using the default translation string')
+    ->blade('<x-support-bubble />')
+    ->assertSee('Submit');

--- a/tests/Components/SupportBubbleComponentTest.php
+++ b/tests/Components/SupportBubbleComponentTest.php
@@ -22,3 +22,8 @@ it('can be configured not to use the logged in user', function () {
         ->assertDontSee('john@example.com')
         ->assertDontSee('John Doe');
 });
+
+it('can render the submit button using the defult translation string', function () {
+    test()->blade('<x-support-bubble />')
+        ->assertSee('Submit');
+});


### PR DESCRIPTION
This PR adds a missing translation of the Submit button (to mirror the translatable behavior of the rest of the form fields).

This won't be a breaking change for people who updated to this patch after previously publishing the translation file.