### PR TITLE
Make notifications a little less clunky when a name isn't provided

### DIFF
--- a/src/Notifications/BubbleResponseNotification.php
+++ b/src/Notifications/BubbleResponseNotification.php
@@ -75,10 +75,10 @@ class BubbleResponseNotification extends Notification implements ShouldQueue
 
     protected function who(): string
     {
-        if ($this->name == null) {
+        if (is_null($this->name)) {
             return $this->email;
         } 
 
-        return $this->name . "(" . $this->email . ")";
+        return "{$this->name} ({$this->email})";
     }
 }

--- a/src/Notifications/BubbleResponseNotification.php
+++ b/src/Notifications/BubbleResponseNotification.php
@@ -75,10 +75,8 @@ class BubbleResponseNotification extends Notification implements ShouldQueue
 
     protected function who(): string
     {
-        if (is_null($this->name)) {
-            return $this->email;
-        } 
-
-        return "{$this->name} ({$this->email})";
+        return is_null($this->name)
+            ? $this->email
+            : "{$this->name} ({$this->email});
     }
 }

--- a/src/Notifications/BubbleResponseNotification.php
+++ b/src/Notifications/BubbleResponseNotification.php
@@ -50,7 +50,7 @@ class BubbleResponseNotification extends Notification implements ShouldQueue
             ->subject("Support bubble message from {$this->name}: {$this->subject}")
             ->replyTo($this->email)
             ->greeting($this->subject)
-            ->line("{$this->name} ({$this->email}) left a new message using the chat bubble:")
+            ->line("{$this->who()} left a new message using the chat bubble:")
             ->line(new HtmlString("<blockquote>{$this->message}</blockquote>"))
             ->line($metadataHtml);
     }
@@ -70,5 +70,15 @@ class BubbleResponseNotification extends Notification implements ShouldQueue
         HTML;
 
         return new HtmlString(trim($html));
+    }
+    
+
+    protected function who(): string
+    {
+        if ($this->name == null) {
+            return $this->email;
+        } 
+
+        return $this->name . "(" . $this->email . ")";
     }
 }

--- a/src/Notifications/BubbleResponseNotification.php
+++ b/src/Notifications/BubbleResponseNotification.php
@@ -77,6 +77,6 @@ class BubbleResponseNotification extends Notification implements ShouldQueue
     {
         return is_null($this->name)
             ? $this->email
-            : "{$this->name} ({$this->email});
+            : "{$this->name} ({$this->email})";
     }
 }


### PR DESCRIPTION
Just took Freek's suggestion from the stream and made the email notification a little less obtuse when the person's name isn't included.