### PR TITLE
Update support-bubble.blade.php

### DIFF
--- a/resources/views/components/support-bubble.blade.php
+++ b/resources/views/components/support-bubble.blade.php
@@ -1,7 +1,7 @@
 <div class="spatie-support-bubble | pointer-events-none fixed bottom-0 {{ $direction === 'right-to-left' ? 'left-0' : 'right-0' }} {{ config('support-bubble.classes.container') }}"
      style="max-width: 340px; display: none;">
-    <div class="spatie-support-bubble__container | pointer-events-auto bg-white shadow-xl border border-gray-300 rounded p-6 transition transform {{ $direction === 'right-to-left' ? '-translate-x-full' : 'translate-x-full' }} opacity-0">
-        <div class="spatie-support-bubble__form">
+    <div class="spatie-support-bubble__container | pointer-events-none bg-white shadow-xl border border-gray-300 rounded p-6 transition transform {{ $direction === 'right-to-left' ? '-translate-x-full' : 'translate-x-full' }} opacity-0">
+        <div class="spatie-support-bubble__form pointer-events-auto">
             @include('support-bubble::includes.form')
         </div>
 


### PR DESCRIPTION
This PR enables pointer-events to pass through the "support-bubble__container" padding which currently masks part of the viewport even when off-canvas.

This fixes the way that it masks the scroll bar if present.