### PR TITLE
add attachment field

### DIFF
--- a/config/support-bubble.php
+++ b/config/support-bubble.php
@@ -11,6 +11,7 @@ return [
         'email' => true,
         'subject' => true,
         'message' => true,
+        'attachment' => true,
     ],
 
     /*
@@ -31,6 +32,11 @@ return [
      * the name and email fields. Both fields will also be hidden.
      */
     'prefill_logged_in_user' => true,
+
+    /**
+     * Choose a disk to store your chat bubble attachments.
+     */
+    'attachment_disk' => null, // by default this is config('filesystems.default')
 
     /*
      * The TailwindCSS classes used on a couple of key components.

--- a/resources/lang/en/support-bubble.php
+++ b/resources/lang/en/support-bubble.php
@@ -9,5 +9,6 @@ return [
     'email_label' => 'E-mail',
     'subject_label' => 'Subject',
     'message_label' => 'How can we help?',
+    'attachment_label' => 'Attachment',
     'submit_label' => 'Submit',
 ];

--- a/resources/lang/it/support-bubble.php
+++ b/resources/lang/it/support-bubble.php
@@ -9,5 +9,6 @@ return [
     'email_label' => 'E-mail',
     'subject_label' => 'Soggetto',
     'message_label' => 'Come possiamo aiutarti?',
+    'attachment_label' => 'Allegato',
     'submit_label' => 'Invia',
 ];

--- a/resources/views/components/attachment-field.blade.php
+++ b/resources/views/components/attachment-field.blade.php
@@ -1,0 +1,18 @@
+@php
+$inputClasses = config('support-bubble.classes.input');
+@endphp
+
+<label for="support-bubble-{{ $name }}" class="font-medium text-sm {{ $hidden ?? false ? 'hidden' : '' }}">
+    {!! $label !!}
+
+    <input type="hidden" name="attachment_key">
+    <input type="hidden" name="attachment_name">
+
+    <input
+        type="file"
+        name="{{ $name }}"
+        id="support-bubble-{{ $name }}"
+        value="{{ $value ?? '' }}"
+        class="{{ $inputClasses }}"
+    >
+</label>

--- a/resources/views/includes/form.blade.php
+++ b/resources/views/includes/form.blade.php
@@ -45,5 +45,12 @@
         />
     @endif
 
+    @if($hasField('attachment'))
+        <x-support-bubble::attachment-field
+            :label="__('support-bubble::support-bubble.attachment_label')"
+            name="attachment"
+        />
+    @endif
+
     <button type="submit" class="{{ config('support-bubble.classes.button') }}">{{ __('support-bubble::support-bubble.submit_label') }}</button>
 </form>

--- a/resources/views/includes/script.blade.php
+++ b/resources/views/includes/script.blade.php
@@ -4,6 +4,7 @@
 
         const container = element.querySelector('.spatie-support-bubble__container');
         const formContainer = element.querySelector('.spatie-support-bubble__form');
+        const submitButton = element.querySelector('button[type=submit]');
         const responseContainer = element.querySelector('.spatie-support-bubble__response');
         const errorMessage = element.querySelector('.spatie-support-bubble__error');
 
@@ -23,13 +24,56 @@
                 if (opening) {
                     responseContainer.style.display = 'none';
                     formContainer.style.display = 'block';
-                    
+
                     container.classList.remove(fullTranslateClass, 'opacity-0');
                     container.classList.add(zeroTranslateClass, 'opacity-100');
                 } else {
                     container.classList.remove(zeroTranslateClass, 'opacity-100');
                     container.classList.add(fullTranslateClass, 'opacity-0');
                 }
+            });
+
+        const attachmentKeyField = element.querySelector('input[name=attachment_key]');
+        const attachmentNameField = element.querySelector('input[name=attachment_name]');
+
+        element
+            .querySelector('input[type=file]')
+            .addEventListener('change', (event) => {
+                const file = event.target.files[0];
+                const fileName = file.name;
+
+                submitButton.disabled = true;
+
+                const formData = new FormData();
+                formData.append('attachment', file);
+
+                fetch('/support-bubble/attach', {
+                    method: 'post',
+                    headers: {Accept: 'application/json'},
+                    body: formData,
+                })
+                    .then(response => {
+                        if (response.status !== 200) throw response;
+
+                        return response.json();
+                    })
+                    .then(attachment => {
+                        errorMessage.style.display = 'none';
+
+                        attachmentKeyField.value = attachment.key;
+                        attachmentNameField.value = attachment.name;
+                    })
+                    .catch(async errorResponse => {
+                        console.error(errorResponse);
+
+                        const response = await errorResponse.json();
+
+                        errorMessage.style.display = 'block';
+                        errorMessage.innerHTML = response.message || 'Something went wrong.';
+                    })
+                    .finally(() => {
+                        submitButton.disabled = false;
+                    });
             });
 
         element

--- a/src/Events/SupportBubbleSubmittedEvent.php
+++ b/src/Events/SupportBubbleSubmittedEvent.php
@@ -15,6 +15,8 @@ class SupportBubbleSubmittedEvent
         public string | null $url,
         public string | null $ip,
         public string | null $userAgent,
+        public string | null $attachmentKey,
+        public string | null $attachmentName,
         public Request $request,
     ) {
     }
@@ -29,6 +31,8 @@ class SupportBubbleSubmittedEvent
             $request->get('url'),
             $request->ip(),
             $request->userAgent(),
+            $request->get('attachment_key'),
+            $request->get('attachment_name'),
             $request
         );
     }

--- a/src/Http/Controllers/HandleSupportBubbleAttachmentController.php
+++ b/src/Http/Controllers/HandleSupportBubbleAttachmentController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\SupportBubble\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class HandleSupportBubbleAttachmentController
+{
+    public function __invoke(Request $request)
+    {
+        $request->validate([
+            'attachment' => ['required'],
+        ]);
+
+        return [
+            'key' => $request->file('attachment')->store('support-bubble-attachments', $this->getDisk()),
+            'name' => $request->file('attachment')->getClientOriginalName(),
+        ];
+    }
+
+    protected function getDisk(): string
+    {
+        if (config('support-bubble.attachment_disk')) {
+            return config('support-bubble.attachment_disk');
+        }
+
+        return config('filesystems.default');
+    }
+}

--- a/src/Http/Requests/SupportBubbleAttachmentRequest.php
+++ b/src/Http/Requests/SupportBubbleAttachmentRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\SupportBubble\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\File;
+
+class SupportBubbleAttachmentRequest extends FormRequest
+{
+    public function rules()
+    {
+        return [
+            'attachment' => ['required'],
+        ];
+    }
+}

--- a/src/SupportBubbleServiceProvider.php
+++ b/src/SupportBubbleServiceProvider.php
@@ -11,6 +11,7 @@ use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\SupportBubble\Components\SupportBubbleComponent;
 use Spatie\SupportBubble\Events\SupportBubbleSubmittedEvent;
+use Spatie\SupportBubble\Http\Controllers\HandleSupportBubbleAttachmentController;
 use Spatie\SupportBubble\Http\Controllers\HandleSupportBubbleSubmissionController;
 use Spatie\SupportBubble\Notifications\BubbleResponseNotification;
 
@@ -28,12 +29,18 @@ class SupportBubbleServiceProvider extends PackageServiceProvider
     public function packageBooted()
     {
         Blade::component('support-bubble', SupportBubbleComponent::class);
+        Blade::component('attachment-field', 'support-bubble::components.attachment-field', 'support-bubble');
         Blade::component('input-field', 'support-bubble::components.input-field', 'support-bubble');
 
         Route::macro('supportBubble', function (string $url = '') {
             Route::post("{$url}/support-bubble", HandleSupportBubbleSubmissionController::class)
                 ->name(config('support-bubble.form_action_route'))
                 ->middleware(ProtectAgainstSpam::class);
+        });
+
+        Route::macro('supportBubbleAttach', function (string $url = '') {
+            Route::post("{$url}/support-bubble/attach", HandleSupportBubbleAttachmentController::class)
+                ->name(config('support-bubble.attach_route'));
         });
 
         if (config('support-bubble.mail_to')) {


### PR DESCRIPTION
This PR adds an attachment field to the chat bubble.

@freekmurze has previously [mentioned](https://github.com/spatie/laravel-support-bubble/discussions/22#discussioncomment-1415745) he'd be open to seeing a PR for attachments if the implementation remains simple. As things have gotten a bit more involved than expected, I’m opening this Draft PR to gauge interest. This is an initial version with no tests yet.

**How it works**

The attachment is uploaded to a new endpoint and stored on a configurable disk. The uploaded file’s key is returned and included in the support bubble form request, allowing the email notification to retrieve and attach the file.

Pre-uploading like this resolves two issues:

1. The email notification may be queued and wouldn’t have access to the file in the form request
2. The support bubble form submits JSON, making this more efficient than say base64 encoding the attachment

**Next steps (if the approach is acceptable)**

- Add tests
- Implement attachment validation (size, type, etc.)
- Improve the attachment input UI (including file removal)
- Tidy up the new javascript
- Add a schedulable job to remove old uploaded files
- Write documentation

**How to try it**

In addition to the usual configuration, be sure to add the `Route::supportBubbleAttach()` method to your **web.php** file and exclude `'support-bubble/attach'` from CSRF verification.

I think this is a really worth while feature, as often it can be easier for a user to show an error they're having with a screenshot than explain it in writing.

Any and all feedback welcome. Thanks in advance.